### PR TITLE
fix : Player클래스의 Character 클래스 상속 및 Enemy 클래스와 상호 변수 이름 맞춤

### DIFF
--- a/sparta_9team_project/sparta_9team_project/Inventory.cs
+++ b/sparta_9team_project/sparta_9team_project/Inventory.cs
@@ -8,6 +8,6 @@ namespace sparta_9team_project
 {
     class Inventory
     {
-        private List<Item> items; = new List<Item>();
+        private List<Item> items = new List<Item>();
     }
 }

--- a/sparta_9team_project/sparta_9team_project/Player.cs
+++ b/sparta_9team_project/sparta_9team_project/Player.cs
@@ -21,14 +21,19 @@ namespace sparta_9team_project
     public class Player : Character
     {
 		// [Fields]
-		public string Name { get; set; } = "미르";
-        public int Level { get; set; } = 1;
-        public int Hp { get; set; }
+
 		public int MaxHp { get; set; } = 100;
-		public int Atk { get; set; }
-		public int Def { get; set; }
-        public JobType Job { get; set; }
+	    public JobType Job { get; set; }
         public string Bones { get; set; }
+
+        public Player (string name, int level, int hp, int maxHp, int atk, int def, JobType job, string bones) : base(name, level, atk, def, hp, maxHp) // 부모 클래스인 Character의 생성자 호출
+        {
+            MaxHp = maxHp;
+            Job = job;
+            Bones = bones;
+        }
+
+
 
 
         // [Methods]
@@ -49,9 +54,7 @@ namespace sparta_9team_project
 
         public void DealDamage(Enemy mob, int damage)
         {
-            Enemy enemy = new Enemy();
-            // 적에게 데미지를 주고 해당 적의 Hp를 줄인다.
-
+            mob.GetDamage(damage);
         }
 
         public void TakeDamage(int damage)

--- a/sparta_9team_project/sparta_9team_project/Player.cs
+++ b/sparta_9team_project/sparta_9team_project/Player.cs
@@ -2,6 +2,12 @@
 
 namespace sparta_9team_project
 {
+    public enum JobType
+    {
+        전사,
+        마법사
+    }
+
     public class  PlayerManager
     {
         public static PlayerManager instance = new PlayerManager();
@@ -11,7 +17,8 @@ namespace sparta_9team_project
             mainPlayer = player;
         }
     }
-    public class Player
+
+    public class Player : Character
     {
 		// [Fields]
 		public string Name { get; set; } = "미르";
@@ -20,7 +27,7 @@ namespace sparta_9team_project
 		public int MaxHp { get; set; } = 100;
 		public int Atk { get; set; }
 		public int Def { get; set; }
-        public string Job { get; set; }
+        public JobType Job { get; set; }
         public string Bones { get; set; }
 
 


### PR DESCRIPTION
01)  Player클래스의 Character 클래스 상속 및 Enemy 클래스와 상호 변수 이름 맞춤