### PR TITLE
delete : 중복되는 스탯 보여주는 함수 Player클래스에서 제거 및 Inventory클래스 함수명 변경

### DIFF
--- a/sparta_9team_project/sparta_9team_project/Inventory.cs
+++ b/sparta_9team_project/sparta_9team_project/Inventory.cs
@@ -46,7 +46,7 @@
                 Console.WriteLine($"{player.Name}의 소지품에 {item.Name}이 없습니다.");
             }
         }
-        public void RemoveCompletely(Item item )
+        public void RemoveAll(Item item )
         {
             if (items.Contains(item))
             {

--- a/sparta_9team_project/sparta_9team_project/Player.cs
+++ b/sparta_9team_project/sparta_9team_project/Player.cs
@@ -38,21 +38,6 @@ namespace sparta_9team_project
 
 
         // [Methods]
-        public void ShowStatus()
-        {
-            Console.Clear();
-
-            Console.WriteLine($"[{Name}의 상태보기]");
-            Console.WriteLine($"{Name, 5} ( {Job} )");
-            Console.WriteLine("-----------------------");
-            Console.WriteLine($"공격력: {Atk}");
-            Console.WriteLine($"방어력: {Def}");
-            Console.WriteLine($"체 력: {Hp} / {MaxHp}");
-            Console.WriteLine($"뼈다귀: {Bones}\n");
-            Console.WriteLine(">> [0] 돌아가기");
-
-        }
-
         public void DealDamage(Enemy mob, int damage)
         {
             Random random = new Random();
@@ -70,7 +55,7 @@ namespace sparta_9team_project
 
         public void TakeDamage(int damage)
         {
-            Hp -=damage;
+            Hp -= damage;
             if (Hp < 0) { Hp = 0; }
 
             ConsoleManager.PrintAnywhere($"{Name}는 {damage}만큼의 댕미지를 입었습니다!",40,25);


### PR DESCRIPTION
01) Player클래스의 스탯을 보여주는 함수인 ShowStatus()함수가 GameManger에 있는 같은 기능을 하는 함수와 중복이되어 삭제하였습니다. 02) Inventory클래스의 함수명 RemoveCompletely()를 조금 더 가독성이 있는 RemoveAll()로 변경하였습니다.